### PR TITLE
Add chance.lua to the 'Utilities' list

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -134,6 +134,7 @@ A categorized community-driven collection of high-quality, awesome LÖVE librari
 
 ## Utilities
 
+* [chance.lua](http://ejmr.github.io/chance.lua/) - Library for generating random data
 * [i18n](https://github.com/excessive/i18n) - Internationalization library designed to help localize your game
 * [love-loader](https://github.com/kikito/love-loader) - Threaded resource loading
 * [love2d-assets-loader](https://github.com/Yonaba/love2d-assets-loader) - Assets Loader


### PR DESCRIPTION
The Chance library provides an API for generating random data, which
can be useful in game development.  For example, using some of the
basic functions one could perform an action ten percent of the time:

    if chance.basic.bool { probability = 10 } then
        spawn_awesome_loot()
    end

Or one could use the library to randomly select from a table of loot,
like an enemy drop table in a role-playing game, e.g.:

    return chance.helpers.pick(loot_table)

Or one could combine the concepts of these two examples by taking
advantage of the library's support for "weighted" arrays, e.g.:

    return chance.misc.weighted(
        {"Common", "Uncommon", "Rare"},
        {75,       20,          5})

This example returns "Common" seventy-five percent of the time,
"Uncommon" twenty-percent of the time, and "Rare" a mere five percent
of the time.

The Chance library also comes with some functions that can be useful
to developers who are specifically working on role-playing games, as
the library can simulate die rolls using notation seen in 'Dungeons
and Dragons' and many other table-top games, such as...

    local initiative_rolls = chance.misc.rpg("5d20")

...which returns an array of five elements, each containing a random
value from rolling a twenty-sided die.

However, the one major drawback to the Chance library at this time of
writing is that it has yet to have its version 1.0.0 release.  There
are currently no plans to break the existing API, but until 1.0.0 it
is nonetheless a moving target.

Signed-off-by: Eric James Michael Ritz <ejmr@plutono.com>
See-Also: http://ejmr.github.io/chance.lua/