### PR TITLE
Add 'log.lua' to the Utilities list

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -156,6 +156,7 @@ A categorized community-driven collection of high-quality, awesome LÖVE librari
 
 * [chance.lua](http://ejmr.github.io/chance.lua/) - Library for generating random data
 * [i18n](https://github.com/excessive/i18n) - Internationalization library designed to help localize your game
+* [log.lua](https://github.com/rxi/log.lua) - Library for configurable log output
 * [love-loader](https://github.com/kikito/love-loader) - Threaded resource loading
 * [love2d-assets-loader](https://github.com/Yonaba/love2d-assets-loader) - Assets Loader
 * [splashy](https://github.com/VideahGams/splashy) - Splash Screen Library


### PR DESCRIPTION
This library is useful for adding configurable logging functionality
to a program.  It allows developers to separate log messages based on
severity, e.g.

    local log = require("log")

    log.trace("Entering enemy AI coroutine")
    log.error("Cannot find given enemy")

By default both calls will produce log messages.  However, by setting
the value of `log.level` to the string `"error"`, only the second call
will record any output, i.e. the call to `log.trace()` becomes a
no-op, thus making it possible for developers to sprinkle various
levels of logging information throughout their software while being
able to disable amounts of it based on the level or severity of the
log messages.

Signed-off-by: Eric James Michael Ritz <ejmr@plutono.com>